### PR TITLE
[Doc] Add badge for documentation of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 <div align="center">
 
 [![javadoc](https://javadoc.io/badge2/fr.tykok/pokeapi/javadoc.svg)](https://javadoc.io/doc/fr.tykok/pokeapi)
-![Maven Central](https://img.shields.io/maven-central/v/fr.tykok/pokeapi)
+[![Maven Central](https://img.shields.io/maven-central/v/fr.tykok/pokeapi)](https://central.sonatype.com/artifact/fr.tykok/pokeapi)
+[![PokeApi Doc](https://img.shields.io/badge/PokeApi_documentation-blue)](https://tykok.github.io/PokeAPI-Kotlin/)
 ![GitHub](https://img.shields.io/github/license/Tykok/PokeAPI-Kotlin)
 
 </div>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,7 +4,7 @@ repo_name: PokeAPI-Kotlin
 site_description: A Kotlin wrapper for the PokeApi
 site_author: Tykok
 site_url: https://tykok.github.io/PokeAPI-Kotlin/
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/mkdocs-markdown/
 docs_dir: mkdocs-markdown
 theme:
   name: readthedocs


### PR DESCRIPTION
# Description

Add badge for the documentation link in the `README.md` and fix the link to the repository in the mkdocs configuration.

# Issues

- #45 
